### PR TITLE
Minor edits

### DIFF
--- a/Line_follow.py
+++ b/Line_follow.py
@@ -8,9 +8,9 @@ from ev3dev.auto import *
 # ------Input--------
 power = 60
 target = 55
-kp = float(0.65) # Start value 1
-kd = 1           # Start value 0
-ki = float(0.02) # Start value 0
+kp = float(0.65)  # Proportional gain
+kd = 1            # Derivative gain
+ki = float(0.02)  # Integral gain
 direction = -1
 minRef = 41
 maxRef = 63
@@ -56,8 +56,7 @@ def steering(course, power):
 			motor.run_forever(speed_sp=power)
 	"""
 
-	pl = power
-	pr = power
+	pl = pr = power
 	s = (50 - abs(float(course))) / 50
 
 	if course >= 0:
@@ -84,14 +83,12 @@ def run(power, target, kp, kd, ki, direction, minRef, maxRef):
 		minRef. Min reflecting value of floor or line
 		maxRef. Max reflecting value of floor or line 
 	"""
-	lastError = 0
-	error = 0
-	integral = 0
+	lastError = error = integral = 0
 	left_motor.run_direct()
 	right_motor.run_direct()
 	lap = 1
 	while not btn.any() :
-		if ts.value():
+		if ts.value():  # user pressed the touch sensor
 			print 'Breaking loop'
 			break
 		refRead = col.value()
@@ -102,7 +99,7 @@ def run(power, target, kp, kd, ki, direction, minRef, maxRef):
 		course = (kp * error + kd * derivative +ki * integral) * direction
 		for (motor, pow) in zip((left_motor, right_motor), steering(course, power)):
 			motor.duty_cycle_sp = pow
-		lap = lap + 1
+		lap += 1
 		sleep(0.01) # Aprox 100 Hz
 
 run(power, target, kp, kd, ki, direction, minRef, maxRef)


### PR DESCRIPTION
The readability of your code will be improved if you use longer variable names.

`power_left` will be easier to understand for readers of your code than `pl`.

If you want to keep the short names then at least put a comment right next to the first assignment.

`pl = pr = 0  # pl is power_left, pr is power_right

kd, ki, kp, pl, pr, s were all unclear to me but they might have well defined meanings within the MindStorms environment.
